### PR TITLE
fix: enable MCP servers from .mcp.json in SDK mode

### DIFF
--- a/src/claude/executor.ts
+++ b/src/claude/executor.ts
@@ -155,6 +155,8 @@ export class ClaudeExecutor {
       includePartialMessages: true,
       // Load MCP servers and settings from user/project config files
       settingSources: ['user', 'project'],
+      // Auto-approve all MCP servers from .mcp.json (SDK mode has no interactive approval)
+      enableAllProjectMcpServers: true,
       // Cross-platform spawn: custom spawn filters CLAUDE* env vars and uses
       // process.execPath to avoid PATH issues on Windows; fileURLToPath converts
       // file:// URLs to native paths for the SDK CLI entrypoint.


### PR DESCRIPTION
## Summary
- Add `enableAllProjectMcpServers: true` to SDK query options in `executor.ts`
- MCP servers from `.mcp.json` are now auto-approved for all bot sessions

Fixes #12

## Test plan
- [ ] Verify `mcp__codex__codex` tool appears in bot sessions with `.mcp.json` configured
- [ ] Confirm MCP tools work on both new and resumed sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)