### PR TITLE
fix: preserve card content on service restart

### DIFF
--- a/src/bridge/message-bridge.ts
+++ b/src/bridge/message-bridge.ts
@@ -816,14 +816,13 @@ export class MessageBridge {
       task.abortController.abort();
       this.logger.info({ chatId }, 'Aborted running task during shutdown');
 
-      // Send final card update so the card doesn't stay stuck in "Running"
+      // Send final card update preserving existing content from the processor
       if (task.cardMessageId) {
+        const currentState = task.processor.processMessage({ type: 'system', subtype: 'noop' } as any);
         const finalState: CardState = {
+          ...currentState,
           status: 'error',
-          userPrompt: '',
-          responseText: '',
-          toolCalls: [],
-          errorMessage: 'Service restarted',
+          errorMessage: task.abortReason || 'Service restarted',
         };
         updatePromises.push(
           this.sender.updateCard(task.cardMessageId, finalState).catch(() => {}),


### PR DESCRIPTION
## Summary
- `destroy()` now reads current state from `task.processor` instead of using empty values
- Card preserves `userPrompt`, `responseText`, `toolCalls` on shutdown

Fixes #13

## Test plan
- [ ] Restart MetaBot while a task is running, verify card retains content
- [ ] Verify `abortReason` is used when available

🤖 Generated with [Claude Code](https://claude.com/claude-code)